### PR TITLE
scripts: Auto remove Docker containers on exit

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -165,7 +165,7 @@ if [[ -z $(docker images -q vic-yocto-builder-4) ]]; then
 else
 	echo "Reusing vic-yocto-builder-4"
 fi
-docker run -it \
+docker run -it --rm \
     -v $(pwd)/anki-deps:/home/$USER/.anki \
     -v $(pwd):$(pwd) \
     -v $(pwd)/build/cache:/home/$USER/.ccache \

--- a/build/clean.sh
+++ b/build/clean.sh
@@ -15,7 +15,7 @@ DIRPATH="$(pwd)"
 
 #docker build --build-arg DIR_PATH="${DIRPATH}" --build-arg USER_NAME=$(whoami) --build-arg UID=$(id -u $USER) --build-arg GID=$(id -g $USER) -t vic-yocto-builder-2 build/
 
-docker run -it \
+docker run -it --rm \
     -v $(pwd)/anki-deps:${HOME}/.anki \
     -v $(pwd):$(pwd) \
     -v $(pwd)/build/cache:${HOME}/.ccache \

--- a/build/run.sh
+++ b/build/run.sh
@@ -15,7 +15,7 @@ DIRPATH="$(pwd)"
 
 #docker build --build-arg DIR_PATH="${DIRPATH}" --build-arg USER_NAME=$(whoami) --build-arg UID=$(id -u $USER) --build-arg GID=$(id -g $USER) -t vic-yocto-builder-2 build/
 
-docker run -it \
+docker run -it --rm \
     -v $(pwd)/anki-deps:${HOME}/.anki \
     -v $(pwd):$(pwd) \
     -v $(pwd)/build/cache:${HOME}/.ccache \

--- a/build/shell.sh
+++ b/build/shell.sh
@@ -15,7 +15,7 @@ DIRPATH="$(pwd)"
 
 #docker build --build-arg DIR_PATH="${DIRPATH}" --build-arg USER_NAME=$(whoami) --build-arg UID=$(id -u $USER) --build-arg GID=$(id -g $USER) -t vic-yocto-builder-2 build/
 
-docker run -it \
+docker run -it --rm \
     -v $(pwd)/anki-deps:${HOME}/.anki \
     -v $(pwd):$(pwd) \
     -v $(pwd)/build/cache:${HOME}/.ccache \


### PR DESCRIPTION
Currently, the containers are not destroyed upon exit. 

Adding the parameter `--rm` to the `docker run` commands of the helper scripts will do it automatically.