### PR TITLE
Restore clock speed control in ankiinit

### DIFF
--- a/poky/victor/meta-vicos/recipes-core/extra-conf/extra-conf/initscripts/ankiinit
+++ b/poky/victor/meta-vicos/recipes-core/extra-conf/extra-conf/initscripts/ankiinit
@@ -4,15 +4,15 @@
 ##  with status 0 and the system init process can continue.
 
 # @nathan-anki  - to stop overheating, limit CPU to 533MHz, RAM to 400MHz
-# this is now handled by wired, theoretically
-# echo 533333 > /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
-# echo disabled > /sys/kernel/debug/msm_otg/bus_voting  # This prevents USB from pinning RAM to 400MHz
-# echo 0 > /sys/kernel/debug/msm-bus-dbg/shell-client/update_request
-# echo 1 > /sys/kernel/debug/msm-bus-dbg/shell-client/mas
-# echo 512 > /sys/kernel/debug/msm-bus-dbg/shell-client/slv
-# echo 0 > /sys/kernel/debug/msm-bus-dbg/shell-client/ab
-# echo active clk2 0 1 max 400000 > /sys/kernel/debug/rpm_send_msg/message # Max RAM freq in KHz = 400MHz
-# echo 1 > /sys/kernel/debug/msm-bus-dbg/shell-client/update_request
+# This didn't get handled by wired as well as you hoped did it?
+echo 533333 > /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
+echo disabled > /sys/kernel/debug/msm_otg/bus_voting  # This prevents USB from pinning RAM to 400MHz
+echo 0 > /sys/kernel/debug/msm-bus-dbg/shell-client/update_request
+echo 1 > /sys/kernel/debug/msm-bus-dbg/shell-client/mas
+echo 512 > /sys/kernel/debug/msm-bus-dbg/shell-client/slv
+echo 0 > /sys/kernel/debug/msm-bus-dbg/shell-client/ab
+echo active clk2 0 1 max 400000 > /sys/kernel/debug/rpm_send_msg/message # Max RAM freq in KHz = 400MHz
+echo 1 > /sys/kernel/debug/msm-bus-dbg/shell-client/update_request
 #End clock speed limits
 
 # Move RT FIFO tasks off core 0 to reduce timer interrupt induced jitter.


### PR DESCRIPTION
Seems robots are overheating from the change of removing clock speed limits from ankiinit