### PR TITLE
Hardcode neofetch ascii and color so that it still works in ADB

### DIFF
--- a/poky/victor/meta-anki/recipes-stupid/neofetch/neofetch/neofetch
+++ b/poky/victor/meta-anki/recipes-stupid/neofetch/neofetch/neofetch
@@ -36,7 +36,7 @@ bash_version=${BASH_VERSINFO[0]:-5}
 shopt -s eval_unsafe_arith &>/dev/null
 
 sys_locale=${LANG:-C}
-XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-${HOME}/.config}
+XDG_CONFIG_HOME=${XDG_CONFIG_HOME:/data/.config}
 PATH=$PATH:/usr/xpg4/bin:/usr/sbin:/sbin:/usr/etc:/usr/libexec
 reset='\e[0m'
 shopt -s nocasematch
@@ -768,7 +768,7 @@ image_backend="ascii"
 # NOTE: 'auto' will pick the best image source for whatever image backend is used.
 #       In ascii mode, distro ascii art will be used and in an image mode, your
 #       wallpaper will be used.
-image_source="auto"
+image_source="/etc/vector-ascii"
 
 
 # Ascii Options
@@ -831,7 +831,7 @@ ascii_distro="auto"
 # Example:
 # ascii_colors=(distro)      - Ascii is colored based on Distro colors.
 # ascii_colors=(4 6 1 8 8 6) - Ascii is colored using these colors.
-ascii_colors=(distro)
+ascii_colors=2
 
 # Bold ascii logo
 # Whether or not to bold the ascii logo.

--- a/poky/victor/meta-qcom/recipes-core/base-files/base-files-3.0.14/profile
+++ b/poky/victor/meta-qcom/recipes-core/base-files/base-files-3.0.14/profile
@@ -20,6 +20,10 @@ if [ -d /etc/profile.d ]; then
 	unset i
 fi
 
+if [ ! -f /data/.config/ ]; then
+	mkdir -p /data/.config/
+fi
+
 # Make sure we are on a serial console (i.e. the device used starts with
 # /dev/tty[A-z]), otherwise we confuse e.g. the eclipse launcher which tries do
 # use ssh
@@ -38,7 +42,7 @@ alias ls="ls --color=auto"
 alias btop="btop --force-utf"
 alias grep='grep --color=auto'
 alias recovery="/sbin/reboot recovery & exit"
-alias neofetch="neofetch --no_config --ascii_colors 2 --ascii /etc/vector-ascii"
+alias neofetch="neofetch --ascii_colors 2 --ascii /etc/vector-ascii"
 alias voff="voff && exit"
 alias mrw="mount -o rw,remount /"
 alias stop_robot="systemctl stop anki-robot.target"


### PR DESCRIPTION
The neofetch ascii art is usually passed through the alias command, this works great for the most part but when you go to access it over adb it shows the stock tux penguin, with this change it does 2 things, one, it always shows the custom Vector "V", and 2 It now saves the configuration file to /data.