### PR TITLE
Useful aliases + vim-tiny

### DIFF
--- a/poky/victor/meta-qcom/recipes-core/base-files/base-files-3.0.14/profile
+++ b/poky/victor/meta-qcom/recipes-core/base-files/base-files-3.0.14/profile
@@ -2,7 +2,7 @@
 # and Bourne compatible shells (bash(1), ksh(1), ash(1), ...).
 
 PATH="/usr/local/bin:/usr/bin:/bin"
-EDITOR="vi"			# needed for packages like cron, git-commit
+EDITOR="vim"			# needed for packages like cron, git-commit
 [ "$TERM" ] || TERM="vt100"	# Basic terminal capab. For screen etc.
 
 # Add /sbin & co to $PATH for the root user
@@ -35,6 +35,9 @@ function reboot() {
 }
 
 alias ls="ls --color=auto"
+alias ll='ls -alF --color=auto'
+alias la='ls -A --color=auto'
+alias l='ls -CF --color=auto'
 alias btop="btop --force-utf"
 alias grep='grep --color=auto'
 alias recovery="/sbin/reboot recovery & exit"
@@ -43,5 +46,6 @@ alias voff="voff && exit"
 alias mrw="mount -o rw,remount /"
 alias stop_robot="systemctl stop anki-robot.target"
 alias start_robot="systemctl start anki-robot.target"
+alias vi='vim'
 
 umask 022

--- a/poky/victor/meta-vicos/recipes-products/images/apq8009/apq8009-anki-robot-image.inc
+++ b/poky/victor/meta-vicos/recipes-products/images/apq8009/apq8009-anki-robot-image.inc
@@ -41,9 +41,10 @@ IMAGE_INSTALL += "liburcu"
 #IMAGE_INSTALL += "ankiprofile"
 
 # dev-only things
+IMAGE_INSTALL += "${@oe.utils.conditional('USER_BUILD', '1', '', 'htop', d)}"
 IMAGE_INSTALL += "${@oe.utils.conditional('USER_BUILD', '1', '', 'nano', d)}"
 IMAGE_INSTALL += "${@oe.utils.conditional('USER_BUILD', '1', '', 'rsync', d)}"
-IMAGE_INSTALL += "${@oe.utils.conditional('USER_BUILD', '1', '', 'htop', d)}"
+IMAGE_INSTALL += "${@oe.utils.conditional('USER_BUILD', '1', '', 'vim-tiny', d)}"
 
 # all the HAL stuff
 IMAGE_INSTALL += "audiohal"


### PR DESCRIPTION
Add some useful aliases, add vim-tiny since it's smaller than vim but has more features than vi which was really needed, symlink vi to vim, vi is still accessible through `/usr/bin/vi`. Adds like 500kb to the final ota size which is negligible.