### PR TITLE
Force upgrade 2.0 bodyboard if it's running DevBuild9c26f10

### DIFF
--- a/anki/rampost/dfu.c
+++ b/anki/rampost/dfu.c
@@ -278,8 +278,10 @@ RampostErr dfu_sequence(const char* dfu_file, bool force_update)
           ++tries;
       }
   }
-  // ignore DevBuild*
-  if (installed_version && strstr((const char*)installed_version, "DevBuild")) {
+  // ignore DevBuild* but not 2.0's devbuild
+  if ((installed_version && strstr((const char*)installed_version, "DevBuild")) && 
+      !(installed_version && strstr((const char*)installed_version, "DevBuild9c26f10"))) 
+  {
     DAS_PRINTHEX(DAS_EVENT, "dfu.installed_version", installed_version, VERSTRING_LEN);
     DAS_LOG(DAS_EVENT, "dfu.success", "ignoring DevBuild");
     return err_OK;


### PR DESCRIPTION
Some 2.0s are shipping with a weird devbuild bodyboard firmware. This normally isn't a issue as people would upgrade to normal firmware which would flash the bodyboard. But now people are skipping directly to unlocking so this is problematic because WireOS and it's forks skip upgrading the bodyboard firmware for devbuilds for prototype bodyboards, but this also causes issues here with 2.0. This PR makes it so that if the bodyboard firmware is that specific bodyboard firmware it'll upgrade it, while preserving firmware on actual DVT bodyboards.

This bodyboard firmware is ok to hardcode as it's consistent across 2.0s
<img width="696" height="945" alt="image" src="https://github.com/user-attachments/assets/1ff53184-6627-4cf5-8fe2-127f5208e3b3" />
<img width="3264" height="2448" alt="image" src="https://github.com/user-attachments/assets/4af8a2b1-3d99-4469-bb70-c213c01157e1" />
